### PR TITLE
I .NET app: Tillat synkron IO på Kestrel callback-endepunkt

### DIFF
--- a/HelseId.Samples.RequestObjectsDemo/ContainedHttpServer.cs
+++ b/HelseId.Samples.RequestObjectsDemo/ContainedHttpServer.cs
@@ -26,7 +26,16 @@ namespace HelseId.RequestObjectsDemo
             _routes = routes;
 
             _host = new WebHostBuilder()
-                .UseKestrel()
+               .UseKestrel(options =>
+               {
+                   /* 
+                    * May enhance out-of-the-box experience when copying code
+                    * or running in .NET5
+                    * See:
+                    * https://stackoverflow.com/questions/47735133/asp-net-core-synchronous-operations-are-disallowed-call-writeasync-or-set-all
+                   */
+                   options.AllowSynchronousIO = true;
+               })
                 .UseUrls(host)
                 .Configure(Configure)
                 .Build();


### PR DESCRIPTION
Hei, for å komme i gang i egen app har jeg kopiert koden i HelseId.RequestObjectsDemo. Jeg fikk da en feil i linje 95 i ContainedHttpServer.SetResult(...) når callback-endepunktet skulle flushe respons, se bilde:
![image](https://user-images.githubusercontent.com/3296458/124601657-635df880-de68-11eb-9176-58e5fee7c511.png)
Flere har visst opplevd dette:
https://stackoverflow.com/questions/47735133/asp-net-core-synchronous-operations-are-disallowed-call-writeasync-or-set-all
Vår kode kjører .NET 5, mulig det er relatert. Jeg har ikke sjekket nøye for sideeffekter, men koden i HelseId.RequestObjectsDemo kjører som før og access-token kommer fint tilbake. I branch ligger en enkel fiks, dere kan jo vurdere om det er interessant :-)