### PR TITLE
Use OidcConstants for SubjectTokenType in exchange request

### DIFF
--- a/HelseId.Samples.TokenExchangeDemo/HelseId.TokenExchangeDemo/Program.cs
+++ b/HelseId.Samples.TokenExchangeDemo/HelseId.TokenExchangeDemo/Program.cs
@@ -110,7 +110,7 @@ namespace HelseId.RefreshTokenDemo
                 ClientId = ActorClientId,
                 Scope = "e-helse:nasjonalt_api/scope",
                 SubjectToken = subjectToken,
-                SubjectTokenType = "urn:ietf:params:oauth:token-type:access_token"            
+                SubjectTokenType = OidcConstants.TokenTypeIdentifiers.AccessToken
             };
 
             return await new HttpClient().RequestTokenExchangeTokenAsync(request);


### PR DESCRIPTION
Siden dere allerede bruker `OidcConstants` flittig, hvorfor ikke bare bruke det her og? 😄 