### PR TITLE
Update READMEs

### DIFF
--- a/SampleApi/README.md
+++ b/SampleApi/README.md
@@ -33,7 +33,7 @@ See [TestTokenProxy README](https://github.com/NorskHelsenett/HelseID.Samples/bl
 
 ### Requirements
 
-The [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) is required to build the program.
+The [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) is required to build the program.
 
 ### Default mode 
 

--- a/Utilities/TestTokenTool/README.md
+++ b/Utilities/TestTokenTool/README.md
@@ -54,7 +54,7 @@ For å få en liste over alle parametrene, kan du bruke kommandoen
 
 
 For å kalle SampleAPI-applikasjonen (i ../../SampleApi-katalogen) med DPoP:
-`dotnet run getToken --createDPoPTokenWithDPoPProof --htuClaimValue https://localhost:5081/machine-clients/dpop-greetings --htmClaimValue GET --callApi
+`dotnet run getToken --createDPoPTokenWithDPoPProof --htuClaimValue https://localhost:5081/machine-clients/greetings --htmClaimValue GET --audience nhn:test-public-samplecode --scope "nhn:test-public-samplecode/client-credentials" --callApi
 `
 
 ### Parametre for å beskrive utput


### PR DESCRIPTION
Updates the README for TestTokenTool to contain a working example of usage with the SampleApi.
- the `--callApi` parameter was previously changed in `#bc64085` to call another endpoint. The htu should reflect this.
- It also seems a `--audience` and `--scope` are now required. The expected values were found in the sample api.

Also updates the 'Requirements'-section to .NET 10.